### PR TITLE
hot fix cors

### DIFF
--- a/JobFinder/Program.cs
+++ b/JobFinder/Program.cs
@@ -87,8 +87,7 @@ builder.Services.AddCors(opt =>
     opt.AddPolicy(AllowAllCorsPolicy,
         builder => builder.AllowAnyOrigin()
             .AllowAnyMethod()
-            .AllowAnyHeader()
-            .AllowCredentials());
+            .AllowAnyHeader());
 });
 builder.Services.AddCors(opt =>
 {


### PR DESCRIPTION
hot fix this error:  Microsoft.AspNetCore.Hosting.Diagnostics[6]
      Application startup exception
      System.InvalidOperationException: The CORS protocol does not allow specifying a wildcard (any) origin and credentials at the same time. Configure the CORS policy by listing individual origins if credentials needs to be supported.
         at Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.Build()
         at Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions.AddPolicy(String name, Action`1 configurePolicy)
